### PR TITLE
Preserve Binding Line Endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Preserve Star Citizen expected EOL for the binding XML files.
+*.xml text eol=crlf


### PR DESCRIPTION
Star Citizen expects CRLF, so set the XML files to that mode.